### PR TITLE
Update NXDrawKit.podspec to set Swift version to 4.0

### DIFF
--- a/NXDrawKit.podspec
+++ b/NXDrawKit.podspec
@@ -20,7 +20,9 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/nicejinux'
 
   s.ios.deployment_target = '8.0'
-
+  
+  s.swift_version = '4.0'
+  
   s.source_files = 'NXDrawKit/Classes/*'
   
   s.resource_bundles = {


### PR DESCRIPTION
Setting Swift version in podspec to 4.0 so that it will build properly until project is fully updated for Swift 4.2.